### PR TITLE
Try/Catch for exception that fires when running in WINE

### DIFF
--- a/Storm/Storm/CecilUtils.cs
+++ b/Storm/Storm/CecilUtils.cs
@@ -38,7 +38,14 @@ namespace Storm
             if (set) sb.Length -= 1;
 
             sb.Append(')');
-            sb.Append(md.ReturnType.Resolve().FullName);
+            try
+            {
+                sb.Append(md.ReturnType.Resolve().FullName);
+            }
+            catch (System.IO.IOException e)
+            {
+                Console.WriteLine(e.ToString());
+            }
             return sb.ToString();
         }
 


### PR DESCRIPTION
There is a large community of those who play this game on OS X and Linux.  I tried to get Storm to work with a popular Wineskin wrapper for OS X.  When launching it throws an exception, seen [here](http://pastie.org/10766541).

Handling this exception with a try/catch fixes the problem enough so that it works fine.  I haven't done extensive testing to figure out what the cause of this problem is, but this is a solution that works and doesn't at all break anything in the process being as simple as it is...

I would still like to figure out what is failing, but only having spent a few minutes of time debugging this, I haven't gotten around to it yet.